### PR TITLE
Fix:  Time regex

### DIFF
--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -22,7 +22,7 @@ use serenity::model::channel::{Message, Reaction};
 
 lazy_static! {
     static ref DATE_REGEX: Regex =
-        Regex::new(r"\b(\d{2})(?:[.:](\d{2}))(pm|am|PM|AM)?\b").unwrap();
+        Regex::new(r"\b([0-9]|0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])\s*([AaPp][Mm])?\b").unwrap();
     static ref TIMEZONE_REGEX: Regex = Regex::new(r"(\w+){1}/(\w+){1}").unwrap();
 }
 


### PR DESCRIPTION
The time regex now supports
`5:00`
`05:00`
`5:00 pm`

PS: We tested in production 😉 